### PR TITLE
check services from cached container service file

### DIFF
--- a/src/Handler/ClassHandler.php
+++ b/src/Handler/ClassHandler.php
@@ -63,6 +63,20 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
                     $className = (string) $expr->args[0]->value->class->getAttribute('resolvedName');
                     $return_type_candidate = new Union([new TNamedObject($className)]);
                 }
+                $classMapFromServiceContainer = self::loadServiceFile($codebase);
+                if ($return_type_candidate && count($classMapFromServiceContainer) && $expr->args[0]->value instanceof Node\Scalar\String_) {
+                    $serviceName = $expr->args[0]->value->value;
+                    if ($serviceName) {
+                        for ($a=0; $a<=count($classMapFromServiceContainer); $a++) {
+                            /** @psalm-suppress MixedArrayAccess */
+                            if($serviceName === $classMapFromServiceContainer[$a]['service']) {
+                                /** @psalm-suppress MixedArrayAccess */
+                                $return_type_candidate = new Union([new TNamedObject($classMapFromServiceContainer[$a]['class'])]);
+                            }
+                        }
+                    }
+                }
+
                 break;
             case 'Symfony\Component\HttpFoundation\Request::getcontent':
                 if ($return_type_candidate) {
@@ -85,4 +99,29 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
                 break;
         }
     }
+
+    private static function loadServiceFile(Codebase $codebase) : array {
+
+        $classServiceMap = [];
+        $simpleXmlConfig = $codebase->config->getPluginClasses()[0]['config'];
+        if (isset($simpleXmlConfig)) {
+            $serviceFiles = $simpleXmlConfig->children();
+            foreach($serviceFiles as $serviceFile) {
+                $serviceFilePath = (string)$serviceFile;
+                if (file_exists($serviceFilePath)) {
+                    $xml = simplexml_load_file($serviceFilePath);
+                    foreach($xml->services->service as $serviceObj) {
+                        $serviceAttributes = $serviceObj ? $serviceObj->attributes() : null;
+                        if ($serviceAttributes && $serviceAttributes['id'] && $serviceAttributes['class']) {
+                            $classServiceMap[] = ['service' => (string)$serviceAttributes['id'], 'class' => (string) $serviceAttributes['class']];
+                        }
+                    }
+                }
+
+            }
+        }
+        return $classServiceMap;
+    }
+
+
 }

--- a/src/Handler/ClassHandler.php
+++ b/src/Handler/ClassHandler.php
@@ -69,12 +69,11 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
                     self::$classServiceMap = self::loadServiceFile($codebase);
                 }
                 if ($return_type_candidate && count(self::$classServiceMap) && $expr->args[0]->value instanceof Node\Scalar\String_) {
-                    $serviceName = $expr->args[0]->value->value;
-                    if (isset($serviceName)) {
-                        if (isset(self::$classServiceMap[$serviceName])) {
-                            $return_type_candidate = new Union([new TNamedObject((string)self::$classServiceMap[$serviceName])]);
-                        }
+                    $serviceName = (string)$expr->args[0]->value->value;
+                    if (isset(self::$classServiceMap[$serviceName])) {
+                        $return_type_candidate = new Union([new TNamedObject((string)self::$classServiceMap[$serviceName])]);
                     }
+
                 }
                 break;
             case 'Symfony\Component\HttpFoundation\Request::getcontent':

--- a/src/Handler/ClassHandler.php
+++ b/src/Handler/ClassHandler.php
@@ -21,10 +21,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAnalysisInterface
 {
-    /** @var array<string,string> */
-    private static $classServiceMap = [];
     /**
-     * {@inheritDoc}
+     * @psalm-var array<string, string>
+     */
+    private static $classServiceMap = [];
+
+    /**
+     * {@inheritdoc}
      */
     public static function afterStatementAnalysis(Node\Stmt\ClassLike $stmt, ClassLikeStorage $classlike_storage, StatementsSource $statements_source, Codebase $codebase, array &$file_replacements = [])
     {
@@ -45,7 +48,7 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function afterMethodCallAnalysis(
         Expr $expr,
@@ -69,11 +72,10 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
                     self::$classServiceMap = self::loadServiceFile($codebase);
                 }
                 if ($return_type_candidate && count(self::$classServiceMap) && $expr->args[0]->value instanceof Node\Scalar\String_) {
-                    $serviceName = (string)$expr->args[0]->value->value;
+                    $serviceName = (string) $expr->args[0]->value->value;
                     if (isset(self::$classServiceMap[$serviceName])) {
-                        $return_type_candidate = new Union([new TNamedObject((string)self::$classServiceMap[$serviceName])]);
+                        $return_type_candidate = new Union([new TNamedObject((string) self::$classServiceMap[$serviceName])]);
                     }
-
                 }
                 break;
             case 'Symfony\Component\HttpFoundation\Request::getcontent':
@@ -97,45 +99,45 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
                 break;
         }
     }
-    /**
-     * @return array<string,string>
-     **/
-    private static function loadServiceFile(Codebase $codebase) : array {
 
+    /**
+     * @todo don't check every time if containerXml config is not set.
+     * @psalm-return array<string, string>
+     */
+    private static function loadServiceFile(Codebase $codebase): array
+    {
         $classServiceMap = [];
         if (count($codebase->config->getPluginClasses())) {
-            foreach ($codebase->config->getPluginClasses() AS $pluginClass) {
-                if ($pluginClass['class'] === str_replace('Handler', 'Plugin',__NAMESPACE__) ) {
+            foreach ($codebase->config->getPluginClasses() as $pluginClass) {
+                if ($pluginClass['class'] === str_replace('Handler', 'Plugin', __NAMESPACE__)) {
                     $simpleXmlConfig = $pluginClass['config'];
                 }
             }
         }
+
         if (isset($simpleXmlConfig) && $simpleXmlConfig instanceof \SimpleXMLElement) {
-            $serviceFiles = $simpleXmlConfig->children();
-            foreach ($serviceFiles as $serviceFile) {
-                $serviceFilePath = (string)$serviceFile;
-                if (!file_exists($serviceFilePath)) {
-                    continue;
-                }
-                $xml = simplexml_load_file($serviceFilePath);
-                if (!$xml->services instanceof \SimpleXMLElement) {
-                    return $classServiceMap;
-                }
-                $services = $xml->services;
-                /** @psalm-suppress MixedAssignment */
-                if (count($services)) {
-                    foreach ($services->service as $serviceObj) {
-                        if (isset($serviceObj) && $serviceObj instanceof \SimpleXMLElement) {
-                            $serviceAttributes = $serviceObj->attributes();
-                            if ($serviceAttributes && isset($serviceAttributes['id']) && isset($serviceAttributes['class'])) {
-                                $classServiceMap[(string)$serviceAttributes['id']] = (string)$serviceAttributes['class'];
-                            }
+            $serviceFilePath = (string) $simpleXmlConfig->containerXml;
+            if (!file_exists($serviceFilePath)) {
+                return [];
+            }
+            $xml = simplexml_load_file($serviceFilePath);
+            if (!$xml->services instanceof \SimpleXMLElement) {
+                return $classServiceMap;
+            }
+            $services = $xml->services;
+            /** @psalm-suppress MixedAssignment */
+            if (count($services)) {
+                foreach ($services->service as $serviceObj) {
+                    if (isset($serviceObj) && $serviceObj instanceof \SimpleXMLElement) {
+                        $serviceAttributes = $serviceObj->attributes();
+                        if ($serviceAttributes && isset($serviceAttributes['id']) && isset($serviceAttributes['class'])) {
+                            $classServiceMap[(string) $serviceAttributes['id']] = (string) $serviceAttributes['class'];
                         }
                     }
                 }
-
             }
         }
+
         return $classServiceMap;
     }
 }


### PR DESCRIPTION
For method case 'Symfony\Component\DependencyInjection\ContainerInterface::get':  the value is a service, so get the class-name from service-file and check this for return.

- use $config parameter for Plugin with 
```
<plugins>
    <pluginClass class="Seferov\SymfonyPsalmPlugin\Plugin">
<children><child>/my/servicecontainer.xml<child></children></pluginClass>
</plugins>
```
 in psalm.xml

- in ClassHandler.php parse the file and check the class 